### PR TITLE
Fixed playlist sidebar overlaying video items

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -137,3 +137,7 @@ ytd-watch-flexy:not([theater]):not([fullscreen]) video {
     height: 100% !important;
     left: 0 !important;
 }
+
+ytd-playlist-sidebar-renderer {
+    left: 0 !important;
+}


### PR DESCRIPTION
Addressed the issue described in #5

Before:
![image](https://user-images.githubusercontent.com/7022144/196700809-6d98c8ac-8d31-455f-8d7e-d5463318cedd.png)

After:
![image](https://user-images.githubusercontent.com/7022144/196701543-c058d693-cd51-409c-9969-555145f82036.png)


Resolves #5 